### PR TITLE
Make istio injection configurable in Profile controller

### DIFF
--- a/components/profile-controller/controllers/monitoring.go
+++ b/components/profile-controller/controllers/monitoring.go
@@ -11,11 +11,12 @@ import (
 const PROFILE = "profile_controller"
 const COMPONENT = "component"
 const KIND = "kind"
+
 // User that make the request
 const REQUSER = "user"
 const ACTION = "action"
 const PATH = "path"
-const SEVERITY  = "severity"
+const SEVERITY = "severity"
 const SEVERITY_MINOR = "minor"
 const SEVERITY_MAJOR = "major"
 const SEVERITY_CRITICAL = "critical"
@@ -59,7 +60,7 @@ func init() {
 }
 
 func IncRequestCounter(kind string) {
-	if len(kind) > MAX_TAG_LEN{
+	if len(kind) > MAX_TAG_LEN {
 		kind = kind[0:MAX_TAG_LEN]
 	}
 	labels := prometheus.Labels{COMPONENT: PROFILE, KIND: kind}
@@ -67,7 +68,7 @@ func IncRequestCounter(kind string) {
 }
 
 func IncRequestErrorCounter(kind string, severity string) {
-	if len(kind) > MAX_TAG_LEN{
+	if len(kind) > MAX_TAG_LEN {
 		kind = kind[0:MAX_TAG_LEN]
 	}
 	labels := prometheus.Labels{COMPONENT: PROFILE, KIND: kind, SEVERITY: severity}

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.StringVar(&userIdHeader, USERIDHEADER, "x-goog-authenticated-user-email", "Key of request header containing user id")
 	flag.StringVar(&userIdPrefix, USERIDPREFIX, "accounts.google.com:", "Request header user id common prefix")
 	flag.StringVar(&workloadIdentity, WORKLOADIDENTITY, "", "Default identity (GCP service account) for workload_identity plugin")
-	flag.BoolVar(&enableIstioInjection, "enable-istio-injection", false,
+	flag.BoolVar(&enableIstioInjection, "enable-istio-injection", true,
 		"Enable Istio sidecar injection at the namespace level. Enabling this will add Istio-specific labels to created namespaces.")
 	flag.Parse()
 

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -53,12 +53,15 @@ func main() {
 	var userIdHeader string
 	var userIdPrefix string
 	var workloadIdentity string
+	var enableIstioInjection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&userIdHeader, USERIDHEADER, "x-goog-authenticated-user-email", "Key of request header containing user id")
 	flag.StringVar(&userIdPrefix, USERIDPREFIX, "accounts.google.com:", "Request header user id common prefix")
 	flag.StringVar(&workloadIdentity, WORKLOADIDENTITY, "", "Default identity (GCP service account) for workload_identity plugin")
+	flag.BoolVar(&enableIstioInjection, "enable-istio-injection", false,
+		"Enable Istio sidecar injection at the namespace level. Enabling this will add Istio-specific labels to created namespaces.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -74,12 +77,13 @@ func main() {
 	}
 
 	if err = (&controllers.ProfileReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Log:              ctrl.Log.WithName("controllers").WithName("Profile"),
-		UserIdHeader:     userIdHeader,
-		UserIdPrefix:     userIdPrefix,
-		WorkloadIdentity: workloadIdentity,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		Log:                   ctrl.Log.WithName("controllers").WithName("Profile"),
+		UserIdHeader:          userIdHeader,
+		UserIdPrefix:          userIdPrefix,
+		WorkloadIdentity:      workloadIdentity,
+		IstioInjectionEnabled: enableIstioInjection,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Profile")
 		os.Exit(1)


### PR DESCRIPTION
This PR adds a new flag to the Profile controller to make Istio injection configurable.

Due to the issues described in https://github.com/kubeflow/kubeflow/issues/4935 we want to allow users making decisions whether they want functionality over the security. Given the ongoing work, it is only Horovod which doesn't have a workaround for making it work on Istio.

### How the changes were tested
* by running `make test`
* by building an image with `make build IMG=mesosphere/kubeflow-dev TAG=dev-profile-controller` and testing it manually