### PR TITLE
Use OperatorVersion CRD instead of Application to get the application version

### DIFF
--- a/components/centraldashboard/app/k8s_service.ts
+++ b/components/centraldashboard/app/k8s_service.ts
@@ -7,26 +7,26 @@ export interface PlatformInfo {
   kubeflowVersion: string;
 }
 
-interface Operator {
+interface V1BetaOperator {
   kind: string;
   name: string;
 }
 
-interface OperatorVersionSpec {
+interface V1BetaOperatorVersionSpec {
   appVersion: string;
-  operator: Operator;
+  operator: V1BetaOperator;
 }
 
 /** Generic definition of the OperatorVersion CRD */
-interface OperatorVersion {
+interface V1BetaOperatorVersion {
   apiVersion: string;
   kind: string;
   metadata?: k8s.V1ObjectMeta;
-  spec: OperatorVersionSpec;
+  spec: V1BetaOperatorVersionSpec;
 }
 
-interface OperatorVersionList {
-  items: OperatorVersion[];
+interface V1BetaOperatorVersionList {
+  items: V1BetaOperatorVersion[];
 }
 
 const OPERATOR_VERSION_API_GROUP = 'kudo.dev';
@@ -135,7 +135,7 @@ export class KubernetesService {
       const _ = (o: any) => o || {};
       const response = await this.customObjectsAPI.listNamespacedCustomObject(
           OPERATOR_VERSION_API_GROUP, OPERATOR_VERSION_API_VERSION, this.namespace, OPERATOR_VERSION_API_NAME);
-      const body = response.body as OperatorVersionList;
+      const body = response.body as V1BetaOperatorVersionList;
       const kubeflowOperatorVersion = (body.items || [])
         .find((app) =>
           /^kubeflow$/i.test(_(_(_(app).spec).operator).name)

--- a/components/centraldashboard/app/k8s_service_test.ts
+++ b/components/centraldashboard/app/k8s_service_test.ts
@@ -210,18 +210,23 @@ describe('KubernetesService', () => {
           }
         ]
       };
-      const listApplicationsResponse = {
+      const listOperatorVersionsResponse = {
         items: [{
-          apiVersion: 'app.k8s.io/v1beta1',
-          kind: 'Application',
-          spec: {descriptor: {type: 'kubeflow', version: '1.0.0'}}
+          apiVersion: 'kudo.dev/v1beta1',
+          kind: 'OperatorVersion',
+          spec: {
+            appVersion: '1.0.0',
+            operator: {
+              name: "kubeflow"
+            }
+          }
         }]
       };
       mockApiClient.listNode.and.returnValue(Promise.resolve(
           {response: mockResponse, body: listNodeResponse as k8s.V1NodeList}));
       mockCustomApiClient.listNamespacedCustomObject.and.returnValue(
           Promise.resolve(
-              {response: mockResponse, body: listApplicationsResponse}));
+              {response: mockResponse, body: listOperatorVersionsResponse}));
 
       const platformInfo = await k8sService.getPlatformInfo();
       expect(platformInfo).toEqual({
@@ -252,18 +257,23 @@ describe('KubernetesService', () => {
           }
         ]
       };
-      const listApplicationsResponse = {
+      const listOperatorVersionsResponse = {
         items: [{
-          apiVersion: 'app.k8s.io/v1beta1',
-          kind: 'Application',
-          spec: {descriptor: {type: 'kubeflow', version: '1.0.0'}}
+          apiVersion: 'kudo.dev/v1beta1',
+          kind: 'OperatorVersion',
+          spec: {
+            appVersion: '1.0.0',
+            operator: {
+              name: "kubeflow"
+            }
+          }
         }]
       };
       mockApiClient.listNode.and.returnValue(Promise.resolve(
           {response: mockResponse, body: response as k8s.V1NodeList}));
       mockCustomApiClient.listNamespacedCustomObject.and.returnValue(
           Promise.resolve(
-              {response: mockResponse, body: listApplicationsResponse}));
+              {response: mockResponse, body: listOperatorVersionsResponse}));
 
       const platformInfo = await k8sService.getPlatformInfo();
       expect(platformInfo).toEqual({


### PR DESCRIPTION
#### Why are the changes needed?
This PR switches to using `OperatorVersion` CRD as a lookup source for getting the Kubeflow version (`appVersion`) in `centraldashboard` app.

These changes are needed because of the exclusion of Application operator from KUDO Kubeflow: https://github.com/mesosphere/kudo-kubeflow/pull/74

#### How were the changes tested?
- by running a test suite as a part of Docker image building process (`make build IMG=mesosphere/kubeflow-dev TAG=centraldashboard-with-operatorversion`)
- by deploying the operator using the updated image and verifying the version is displayed on the dashboard and return via API call to `<cluster_address>/api/workgroup/env-info`
