### PR TITLE
Removing vendor links from central dashboard

### DIFF
--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -42,40 +42,6 @@ export class DashboardView extends PolymerElement {
                             'running on Kubeflow',
                         link: `${DOCS}/started/getting-started/`,
                     },
-                    {
-                        text: 'MiniKF',
-                        desc: 'A fast and easy way to deploy Kubeflow locally',
-                        link: `${DOCS}/started/getting-started-minikf/`,
-                    },
-                    {
-                        text: 'Microk8s for Kubeflow',
-                        desc: 'Quickly get Kubeflow running locally on ' +
-                            'native hypervisors',
-                        link: `${DOCS}/started/getting-started-multipass/`,
-                    },
-                    {
-                        text: 'Minikube for Kubeflow',
-                        desc: 'Quickly get Kubeflow running locally',
-                        link: `${DOCS}/started/getting-started-minikube/`,
-                    },
-                    {
-                        text: 'Kubeflow on GCP',
-                        desc: 'Running Kubeflow on Kubernetes Engine and ' +
-                            'Google Cloud Platform',
-                        link: `${DOCS}/gke/`,
-                    },
-                    {
-                        text: 'Kubeflow on AWS',
-                        desc: 'Running Kubeflow on Elastic Container Service ' +
-                            'and Amazon Web Services',
-                        link: `${DOCS}/aws/`,
-                    },
-                    {
-                        text: 'Requirements for Kubeflow',
-                        desc: 'Get more detailed information about using ' +
-                'Kubeflow and its components',
-                        link: `${DOCS}/started/requirements/`,
-                    },
                 ],
             },
             namespace: String,

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -19,10 +19,10 @@ div#grid
                 external-link='[[platformDetails.resourceChartsLink]]'
                 external-link-text='[[platformDetails.resourceChartsLinkText]]')
     .column
-        notebooks-card(namespace='[[namespace]]')
         pipelines-card(heading='Recent Pipelines', artifact-type='pipelines')
         pipelines-card(heading='Recent Pipeline Runs', artifact-type='runs')
     .column
+        notebooks-card(namespace='[[namespace]]')
         template(is='dom-if', if='[[platformDetails.links]]')
             paper-card#Platform-Links(class$='[[platformDetails.name]]',
                 heading='[[platformDetails.title]]', image='[[platformDetails.logo]]')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -32,10 +32,6 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 paper-item.menu-item Documentation
                     iron-icon.external(icon="launch")
         footer.footer
-            section.information
-                a.privacy(title='Kubeflow Privacy Policy', target='_blank', href='https://policies.google.com/privacy') Privacy
-                .bullet
-                a.usage(title='Kubeflow Usage Reporting', target='_blank', href='https://www.kubeflow.org/docs/other-guides/usage-reporting/') Usage Reporting
             section.build build version&nbsp;
                 span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]] | Isolation-Mode: [[isolationMode]]") [[buildVersion]]
     app-header-layout(fullbleed)


### PR DESCRIPTION
This PR removes vendor links from the central dashboard to avoid binding.