### PR TITLE
Parameterize authorized namespaces for Istio AuthorizationPolicy

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -45,9 +45,10 @@ type KfamV1Alpha1Client struct {
 	clusterAdmin []string
 	userIdHeader string
 	userIdPrefix string
+	authorizedNamespaces []string
 }
 
-func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string) (*KfamV1Alpha1Client, error) {
+func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string, authorizedNamespaces []string) (*KfamV1Alpha1Client, error) {
 	profileRESTClient, err := getRESTClient(profileRegister.GroupName, profileRegister.GroupVersion)
 	if err != nil {
 		return nil, err
@@ -75,6 +76,7 @@ func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string
 		clusterAdmin: []string{clusterAdmin},
 		userIdHeader: userIdHeader,
 		userIdPrefix: userIdPrefix,
+		authorizedNamespaces: authorizedNamespaces,
 	}, nil
 }
 
@@ -104,7 +106,7 @@ func (c *KfamV1Alpha1Client) CreateBinding(w http.ResponseWriter, r *http.Reques
 	// check permission before create binding
 	useremail := c.getUserEmail(r.Header)
 	if c.isOwnerOrAdmin(useremail, binding.ReferredNamespace) {
-		err := c.bindingClient.Create(&binding, c.userIdHeader, c.userIdPrefix)
+		err := c.bindingClient.Create(&binding, c.userIdHeader, c.userIdPrefix, c.authorizedNamespaces)
 		if err != nil {
 			IncRequestErrorCounter(err.Error(), useremail, action, r.URL.Path,
 				SEVERITY_MAJOR)

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -45,7 +45,7 @@ var roleBindingNameMap = map[string]string{
 }
 
 type BindingInterface interface {
-	Create(binding *Binding, userIdHeader string, userIdPrefix string) error
+	Create(binding *Binding, userIdHeader string, userIdPrefix string, authorizedNamespaces []string) error
 	Delete(binding *Binding) error
 	List(user string, namespaces []string, role string) (*BindingEntries, error)
 }
@@ -74,7 +74,7 @@ func getBindingName(binding *Binding) (string, error) {
 	return reg.ReplaceAllString(nameRaw, "-"), nil
 }
 
-func (c *BindingClient) Create(binding *Binding, userIdHeader string, userIdPrefix string) error {
+func (c *BindingClient) Create(binding *Binding, userIdHeader string, userIdPrefix string, authorizedNamespaces []string) error {
 	// TODO: permission check before go ahead
 	bindingName, err := getBindingName(binding)
 	if err != nil {
@@ -107,6 +107,16 @@ func (c *BindingClient) Create(binding *Binding, userIdHeader string, userIdPref
 		},
 		Spec: istioapi.AuthorizationPolicy{
 			Rules: []*istioapi.Rule{
+				{
+					From: []*istioapi.Rule_From{
+						{
+							Source: &istioapi.Source{
+								Namespaces: append(authorizedNamespaces, binding.ReferredNamespace),
+							},
+						},
+
+					},
+				},
 				{
 					When: []*istioapi.Condition{
 						{

--- a/components/access-management/main.go
+++ b/components/access-management/main.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes/scheme"
 	"net/http"
+	"strings"
 
 	"github.com/kubeflow/kubeflow/components/access-management/kfam"
 	profile "github.com/kubeflow/kubeflow/components/access-management/pkg/apis/kubeflow/v1beta1"
@@ -29,21 +30,29 @@ const USERIDPREFIX = "userid-prefix"
 // set cluster admin user id here.
 const CLUSTERADMIN = "cluster-admin"
 
+const AuthohhrizedNamespaces = "allow-access-from-namespaces"
 
 func main() {
 	log.Printf("Server started")
 	var userIdHeader string
 	var userIdPrefix string
 	var clusterAdmin string
+	var defaultAuthorizedNamespaces string
 	flag.StringVar(&userIdHeader, USERIDHEADER, "x-goog-authenticated-user-email", "Key of request header containing user id")
 	flag.StringVar(&userIdPrefix, USERIDPREFIX, "accounts.google.com:", "Request header user id common prefix")
 	flag.StringVar(&clusterAdmin, CLUSTERADMIN, "", "cluster admin")
+	flag.StringVar(&defaultAuthorizedNamespaces, AuthohhrizedNamespaces, "", "Comma-separated string of namespace names to allow access from and include into Istio AuthorizationPolicy")
 	flag.Parse()
 
 	profile.AddToScheme(scheme.Scheme)
 	istio.AddToScheme(scheme.Scheme)
 
-	profileClient, err := kfam.NewKfamClient(userIdHeader, userIdPrefix, clusterAdmin)
+	var authorizedNamespaces []string
+	if len(defaultAuthorizedNamespaces) != 0 {
+		authorizedNamespaces = strings.Split(defaultAuthorizedNamespaces, ",")
+	}
+
+	profileClient, err := kfam.NewKfamClient(userIdHeader, userIdPrefix, clusterAdmin, authorizedNamespaces)
 	if err != nil {
 		log.Print(err)
 		panic(err)

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -82,11 +82,12 @@ type Plugin interface {
 // ProfileReconciler reconciles a Profile object
 type ProfileReconciler struct {
 	client.Client
-	Scheme           *runtime.Scheme
-	Log              logr.Logger
-	UserIdHeader     string
-	UserIdPrefix     string
-	WorkloadIdentity string
+	Scheme               *runtime.Scheme
+	Log                  logr.Logger
+	UserIdHeader         string
+	UserIdPrefix         string
+	WorkloadIdentity     string
+	AuthorizedNamespaces []string
 }
 
 // Reconcile reads that state of the cluster for a Profile object and makes changes based on the state read
@@ -343,6 +344,15 @@ func (r *ProfileReconciler) updateIstioAuthzPolicy(profileIns *profilev1.Profile
 		},
 		Spec: istioapi.AuthorizationPolicy{
 			Rules: []*istioapi.Rule{
+				{
+					From: []*istioapi.Rule_From{
+						{
+							Source: &istioapi.Source{
+								Namespaces: append(r.AuthorizedNamespaces, profileIns.Name),
+							},
+						},
+					},
+				},
 				{
 					When: []*istioapi.Condition{
 						{


### PR DESCRIPTION
It's been discovered during the tests of KFServing that KNative Serving activator is unable to health check the deployed pod due to access control issues. This PR makes the list of authorized namespaces configurable to allow administrators specifying a list of namespaces which can access the user namespace.