### PR TITLE
Hide server type controls from the Notebook Spawner UI

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.scss
@@ -4,6 +4,5 @@
 }
 
 .server-type-wrapper {
-  margin-bottom: 1rem;
-  width: fit-content;
+  display: none;
 }


### PR DESCRIPTION
This PR changes CSS rules to hide server type group controls from the Notebook Spawner UI since we don't support the integration with VSCode and R-Studio.