### PR TITLE
Add support for PodSecurityContext to PodDefault

### DIFF
--- a/components/admission-webhook/README.md
+++ b/components/admission-webhook/README.md
@@ -13,7 +13,7 @@ Here is the workflow on how this is used in Kubeflow:
 1. Users create  PodDefault manifests which describe additional runtime requirements (i.e., volume, volumeMounts, environment variables) to be injected  into a Pod at creation time.
 PodDefaults use label selectors to specify the Pods to which a given PodDefault applies.
 PodDefaults are namespace scope, i.e., they can be applied/viewed in the namespace.  
-As an example, the following manifest declares a PodPrest in `kubeflow` namespace to add the secret ```gcp-secret``` in to pods in the given namespace. 
+As an example, the following manifest declares a PodDefault in `kubeflow` namespace to add the secret ```gcp-secret``` in to pods in the given namespace.
 
 ```
 apiVersion: "kubeflow.org/v1alpha1"

--- a/components/admission-webhook/main.go
+++ b/components/admission-webhook/main.go
@@ -338,6 +338,32 @@ func mergeTolerations(tolerations []corev1.Toleration, podDefaults []*settingsap
 	return mergedTolerations, err
 }
 
+// getSecurityContext scans through the matching PodDefaults and returns a PodSecurityContext
+// if it is provided. Returns an error if there are multiple conflicting PodSecurityContexts specified.
+func getSecurityContext(podDefaults []*settingsapi.PodDefault) (*corev1.PodSecurityContext, error) {
+	var securityContext corev1.PodSecurityContext
+	podDefaultName := ""
+
+	for _, pd := range podDefaults {
+		if pd.Spec.SecurityContext.Size() > 0 {
+			if securityContext.Size() == 0 {
+				securityContext = pd.Spec.SecurityContext
+				podDefaultName = pd.Name
+			} else {
+				if !reflect.DeepEqual(securityContext, pd.Spec.SecurityContext) {
+					return nil, fmt.Errorf("conflicting security contexts in pod defaults %s and %s, skipping", podDefaultName, pd.Name)
+				}
+			}
+		}
+	}
+
+	if securityContext.Size() == 0 {
+		return nil, nil
+	}
+
+	return &securityContext, nil
+}
+
 // mergeMap copies the existing map and adds the keys in defaults. It returns
 // an error if it detects any conflict during the merge.
 func mergeMap(existing map[string]string, defaults []*map[string]string) (map[string]string, error) {
@@ -384,6 +410,13 @@ func applyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.PodDefaul
 		klog.Error(err)
 	}
 	pod.Spec.Tolerations = tolerations
+
+	securityContext, err := getSecurityContext(podDefaults)
+	if err != nil {
+		klog.Error(err)
+	} else {
+		pod.Spec.SecurityContext = securityContext
+	}
 
 	var (
 		defaultAnnotations = make([]*map[string]string, len(podDefaults))

--- a/components/admission-webhook/main_test.go
+++ b/components/admission-webhook/main_test.go
@@ -190,3 +190,133 @@ func TestApplyPodDefaultsOnPod(t *testing.T) {
 	}
 
 }
+
+func TestApplyPodDefaultsSecurityContextOnPod(t *testing.T) {
+	idOne := int64(1)
+	idTwo := int64(2)
+
+	scOne := corev1.PodSecurityContext{
+		RunAsUser:	&idOne,
+		RunAsGroup: &idOne,
+		FSGroup: &idOne,
+	}
+
+	scTwo := corev1.PodSecurityContext{
+		RunAsUser:	&idTwo,
+		RunAsGroup: &idTwo,
+		FSGroup: &idTwo,
+	}
+
+	for _, test := range []struct {
+		name        string
+		in          *corev1.Pod
+		podDefaults []*settingsapi.PodDefault
+		out         *corev1.Pod
+	}{
+		{
+			"Add Pod Security Context",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+			[]*settingsapi.PodDefault{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-default",
+					},
+					Spec: settingsapi.PodDefaultSpec{
+						SecurityContext: scOne,
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"poddefault.admission.kubeflow.org/poddefault-test-pod-default": "",
+					},
+					Labels: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &scOne,
+				},
+			},
+		}, {
+			"Add Security Context when similar values specified in multiple PodDefaults",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+			[]*settingsapi.PodDefault{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-default",
+					},
+					Spec: settingsapi.PodDefaultSpec{
+						SecurityContext: scOne,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-default-two",
+					},
+					Spec: settingsapi.PodDefaultSpec{
+						SecurityContext: scOne,
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"poddefault.admission.kubeflow.org/poddefault-test-pod-default": "",
+						"poddefault.admission.kubeflow.org/poddefault-test-pod-default-two":"",
+					},
+					Labels: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					SecurityContext: &scOne,
+				},
+			},
+		}, {
+			"Skip adding Security Context when different values specified in multiple PodDefaults",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{},
+			},
+			[]*settingsapi.PodDefault{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-default",
+					},
+					Spec: settingsapi.PodDefaultSpec{
+						SecurityContext: scOne,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-default-two",
+					},
+					Spec: settingsapi.PodDefaultSpec{
+						SecurityContext: scTwo,
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"poddefault.admission.kubeflow.org/poddefault-test-pod-default": "",
+						"poddefault.admission.kubeflow.org/poddefault-test-pod-default-two":"",
+					},
+					Labels: map[string]string{},
+				},
+				Spec: corev1.PodSpec{},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := safeToApplyPodDefaultsOnPod(test.in, test.podDefaults); err != nil {
+				t.Fatal(err)
+			}
+			applyPodDefaultsOnPod(test.in, test.podDefaults)
+			if !reflect.DeepEqual(test.in, test.out) {
+				t.Fatalf("%#v\n  Not Equals:\n%#v", test.in.ObjectMeta, test.out.ObjectMeta)
+			}
+		})
+	}
+}

--- a/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
+++ b/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
@@ -61,6 +61,9 @@ type PodDefaultSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+
+	// SecurityContext allows to specify PodSecurityContext for a pod.
+	SecurityContext v1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 // PodDefaultStatus defines the observed state of PodDefault


### PR DESCRIPTION
This PR is a port of the changes from https://github.com/kubeflow/kubeflow/pull/5986. Please also check this comment for the motivation for this change https://github.com/kubeflow/kubeflow/pull/5986#issuecomment-863499248.