### PR TITLE
CVEs - Update versions for fixed CVEs in kubeflow centraldashboard component

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -19,6 +19,9 @@ RUN apk add --no-cache bash@stable chromium@stable nss@stable \
     ttf-freefont@stable \
     libstdc++@stable
 
+RUN apk update && apk upgrade && \
+    echo @stable http://nl.alpinelinux.org/alpine/v3.16/main >> /etc/apk/repositories
+
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
         apk update && apk upgrade && \
         apk add --no-cache python2 make g++@stable; \

--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -19,9 +19,6 @@ RUN apk add --no-cache bash@stable chromium@stable nss@stable \
     ttf-freefont@stable \
     libstdc++@stable
 
-RUN apk update && apk upgrade && \
-    echo @stable http://nl.alpinelinux.org/alpine/v3.16/main >> /etc/apk/repositories
-
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
         apk update && apk upgrade && \
         apk add --no-cache python2 make g++@stable; \
@@ -46,6 +43,10 @@ RUN npm rebuild && \
 FROM node:12.22.8-alpine AS serve
 
 ENV NODE_ENV=production
+
+RUN apk update && apk upgrade && \
+    echo @stable http://nl.alpinelinux.org/alpine/v3.16/main >> /etc/apk/repositories
+
 WORKDIR /app
 COPY --from=build /centraldashboard .
 

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -7239,7 +7239,7 @@
             "dev": true
         },
         "json-schema": {
-            "version": "0.2.3",
+            "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
@@ -7313,7 +7313,7 @@
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
+                "json-schema": "0.4.0",
                 "verror": "1.10.0"
             }
         },

--- a/components/centraldashboard/third_party/license_info.csv
+++ b/components/centraldashboard/third_party/license_info.csv
@@ -737,7 +737,7 @@ json-bigint@0.3.0,https://github.com/sidorares/json-bigint/tree/master/LICENSE,M
 json-parse-better-errors@1.0.2,https://github.com/zkat/json-parse-better-errors/tree/latest/LICENSE.md,MIT,https://raw.githubusercontent.com/zkat/json-parse-better-errors/latest/LICENSE.md
 json-schema-traverse@0.3.1,https://github.com/epoberezkin/json-schema-traverse/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/epoberezkin/json-schema-traverse/master/LICENSE
 json-schema-traverse@0.4.1,https://github.com/epoberezkin/json-schema-traverse/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/epoberezkin/json-schema-traverse/master/LICENSE
-json-schema@0.2.3,https://github.com/kriszyp/json-schema/tree/master/README.md,AFLv2.1,BSD
+json-schema@0.4.0,https://github.com/kriszyp/json-schema/tree/master/README.md,AFLv2.1,BSD
 json-stable-stringify-without-jsonify@1.0.1,https://github.com/samn/json-stable-stringify/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/samn/json-stable-stringify/master/LICENSE
 json-stringify-safe@5.0.1,https://github.com/isaacs/json-stringify-safe/tree/master/LICENSE,ISC,https://raw.githubusercontent.com/isaacs/json-stringify-safe/master/LICENSE
 json3@3.3.3,https://github.com/bestiejs/json3/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/bestiejs/json3/master/LICENSE


### PR DESCRIPTION
Relates to issue [D2iQ-90506](https://jira.d2iq.com/browse/D2IQ-90506)

- Updating minimist version to 1.2.6 to patch/fix [this CVE](https://github.com/advisories/GHSA-xvch-5gv4-984h)
- Updating json-schema version to 0.4.0 to patch/fix [this CVE](https://github.com/advisories/GHSA-896r-f27r-55mw)
- Updating alpine linux (in the dockerfile) to v3.16 to patch [this CVE](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28391)

To check:
can/should I update json-schema references in components/centraldashboard/third_party?